### PR TITLE
[WIP]chat-spaceテーブル

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false|
+### Association
+- has_many :posts
+- has_many :comments
+
+## postsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|title|text|null: false|
+|text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- has_many :comments
+
+## tagsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+### Association
+- has_many :posts_tags
+- has_many  :posts,  through:  :posts_tags
+
+## posts_tagsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|post_id|integer|null: false, foreign_key: true|
+|tag_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :post
+- belongs_to :tag
+
+
+## commentsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :post
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _ has_many :messages
 ## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|integer|null: false, foreign_key: true|
+|group_name|string|null: false, foreign_key: true|
 |username|string|null: false, foreign_key: true|
 ### Association
 - belongs_to :users

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Things you may want to cover:
 |password|string|null: false|
 |username|string|null: false|
 ### Association
-- has_many :posts
-- has_many :comments
-_ has many : groups
+- has_many :messages
+_ has many : groups, through:  :users_groups
 
 ## messagesテーブル
 |Column|Type|Options|
@@ -50,7 +49,7 @@ _ belongs_to :groups
 |------|----|-------|
 |text|text|null: false|
 ### Association
-- has_many :users
+- has_many :users, through:  :users_groups
 _ has_many :messages
 
 ## users_groupsテーブル

--- a/README.md
+++ b/README.md
@@ -46,8 +46,16 @@ Things you may want to cover:
 ## replyテーブル
 |Column|Type|Options|
 |------|----|-------|
+|text|text|null: false|
+### Association
+- has_many :post_reply
+- has_many  :posts,  through:  :posts_tags
+
+## posts_replyテーブル
+|Column|Type|Options|
+|------|----|-------|
 |post_id|integer|null: false, foreign_key: true|
 |tag_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :post
 - belongs_to :user
+- belongs_to :tag

--- a/README.md
+++ b/README.md
@@ -42,30 +42,12 @@ Things you may want to cover:
 - belongs_to :user
 - has_many :comments
 
-## tagsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|text|text|null: false|
-### Association
-- has_many :posts_tags
-- has_many  :posts,  through:  :posts_tags
 
-## posts_tagsテーブル
+## replyテーブル
 |Column|Type|Options|
 |------|----|-------|
 |post_id|integer|null: false, foreign_key: true|
 |tag_id|integer|null: false, foreign_key: true|
-### Association
-- belongs_to :post
-- belongs_to :tag
-
-
-## commentsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|text|text|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :post
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ _ has many : groups, through:  :users_groups
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|title|text|null: false|
 |text|text|null: false|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
@@ -48,6 +47,8 @@ _ belongs_to :groups
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
+|username|string|null: false|
+|group_name|string|null: false|
 ### Association
 - has_many :users, through:  :users_groups
 _ has_many :messages
@@ -55,8 +56,8 @@ _ has_many :messages
 ## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|post_id|integer|null: false, foreign_key: true|
-|tag_id|integer|null: false, foreign_key: true|
+|group_name|integer|null: false, foreign_key: true|
+|username|string|null: false, foreign_key: true|
 ### Association
 - belongs_to :users
 - belongs_to :groups

--- a/README.md
+++ b/README.md
@@ -28,36 +28,38 @@ Things you may want to cover:
 |email|string|null: false|
 |password|string|null: false|
 |username|string|null: false|
+|groups|string|null: false|
 ### Association
 - has_many :messages
+_ has_many :users_groups
 _ has many : groups, through:  :users_groups
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
+|image|string||
 |user_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :user
-- has_many :messages
-_ belongs_to :groups
+- belongs_to :user :through:  :users_groups
+_ belongs_to :group :through:  :users_groups
 
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
-|username|string|null: false|
-|group_name|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :users, through:  :users_groups
 _ has_many :messages
+_ has_many :users_groups
 
-## users_groupsテーブル
+## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false, foreign_key: true|
-|username|string|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
 ### Association
-- belongs_to :users
-- belongs_to :groups
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Things you may want to cover:
 - has_many :comments
 _ has many : groups
 
-## postsテーブル
+## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |title|text|null: false|
@@ -41,8 +41,8 @@ _ has many : groups
 |user_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
-- has_many :comments
-_ has_many :groups
+- has_many :messages
+_ belongs_to :groups
 
 
 ## groupsテーブル
@@ -51,6 +51,7 @@ _ has_many :groups
 |text|text|null: false|
 ### Association
 - has_many :users
+_ has_many :messages
 
 ## users_groupsテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false|
-|groups|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 _ has_many :users_groups
@@ -40,9 +39,10 @@ _ has many : groups, through:  :users_groups
 |text|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :user :through:  :users_groups
-_ belongs_to :group :through:  :users_groups
+- belongs_to :user 
+_ belongs_to :group
 
 
 ## groupsテーブル

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Things you may want to cover:
 ### Association
 - has_many :posts
 - has_many :comments
+_ has many : groups
 
 ## postsテーブル
 |Column|Type|Options|
@@ -41,21 +42,21 @@ Things you may want to cover:
 ### Association
 - belongs_to :user
 - has_many :comments
+_ has_many :groups
 
 
-## replyテーブル
+## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
 ### Association
-- has_many :post_reply
-- has_many  :posts,  through:  :posts_tags
+- has_many :users
 
-## posts_replyテーブル
+## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |post_id|integer|null: false, foreign_key: true|
 |tag_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :user
-- belongs_to :tag
+- belongs_to :users
+- belongs_to :groups


### PR DESCRIPTION
What
usersテーブルなカラム名の変更。
usersテーブルのアソシエーションにgroupsの記載があるのでカラムから削除。
messageテーブルにgroup_idの追加。
groups_usersテーブルのアソシエーションからthrough: :users_groupsを削除。


Why
nameテーブルのカラムにわざわざusernameと書かなくても明らかだから。
usersテーブルのアソシエーションにgroupsの記載があるため。
messageテーブルにgroup_idを外部キーとして入れるため。
不必要だったため。


